### PR TITLE
chore(cargo): add link to repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "commentator"
 version = "0.2.3"
 edition = "2018"
 license = "MIT"
+repository = "https://github.com/g4s8/commentator"
 description = "Source code comments extractor binary and SDK"
 
 [dependencies]


### PR DESCRIPTION
Adds a link to the repository.

This makes it easy to find the repository either from `crates.io`,
or `docs.rs`, by just following the link.